### PR TITLE
GLOB_BRACE isn't supported on all systems

### DIFF
--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -121,7 +121,7 @@ class Frontend {
 		$refresh_css = array_key_exists( 'refresh_css', $_GET );
 		$current     = get_transient( $this->cache_key );
 		$css_dir     = $this->uploads['basedir'];
-		$css_file    = glob( "{$css_dir}/teccc*.{css}", GLOB_BRACE );
+		$css_file    = glob( "{$css_dir}/teccc*.css" );
 		$current     = ! empty( $css_file ) && strpos( $css_file[0], $this->cache_key )
 			? $current
 			: false;
@@ -145,7 +145,7 @@ class Frontend {
 		}
 		$css_min = $this->minify_css( $css );
 
-		foreach ( glob( "{$css_dir}/teccc*.{css}", GLOB_BRACE ) as $file ) {
+		foreach ( glob( "{$css_dir}/teccc*.css" ) as $file ) {
 			unlink( $file );
 		}
 		file_put_contents( "{$css_dir}/{$this->cache_key}.css", $css );


### PR DESCRIPTION
Noticed this when running on a Alpine-based Docker container.  

```
PHP Warning:  Use of undefined constant GLOB_BRACE - assumed 'GLOB_BRACE' (this will throw an Error in a future version of PHP) in /www/site/wp-content/plugins/the-events-calendar-category-colors/src/Category_Colors/Frontend.php on line 148
PHP Warning:  glob() expects parameter 2 to be integer, string given in /www/site/wp-content/plugins/the-events-calendar-category-colors/src/Category_Colors/Frontend.php on line 148
PHP Warning:  Invalid argument supplied for foreach() in /www/site/wp-content/plugins/the-events-calendar-category-colors/src/Category_Colors/Frontend.php on line 148
```

As per the PHP docs:  `Note: The GLOB_BRACE flag is not available on some non GNU systems, like Solaris.`