### PR TITLE
Jquery fix

### DIFF
--- a/src/Category_Colors/Admin.php
+++ b/src/Category_Colors/Admin.php
@@ -201,6 +201,7 @@ class Admin {
 				'add_legend_week_view',
 				'add_legend_photo_view',
 				'add_legend_map_view',
+				'add_legend_summary_view',
 			];
 
 			$generalOptions = array_merge( $generalOptions, $ecp_settings );

--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -288,13 +288,17 @@ class Frontend {
 	public function show_legend() {
 		$v2_viewable   = false !== strpos( $this->legendTargetHook, $this->currentDisplay );
 		$is_extra_view = in_array( $this->currentDisplay, $this->legendExtraView, true );
+//		var_dump($this->options['add_legend']);
 		if ( ! $v2_viewable && ! $is_extra_view ) {
 			return false;
 		}
 		if ( $this->legendFilterHasRun ) {
 			return false;
 		}
-		if ( ! ( isset( $this->options['add_legend'] ) && '1' === $this->options['add_legend'] ) ) {
+		/*if ( ! ( isset( $this->options['add_legend'] ) && '1' === $this->options['add_legend'] ) ) {
+			//return false;
+		}*/
+		if ( ! isset( $this->options['add_legend'] ) || null === $this->options['add_legend'] ) {
 			return false;
 		}
 

--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -298,7 +298,11 @@ class Frontend {
 		/*if ( ! ( isset( $this->options['add_legend'] ) && '1' === $this->options['add_legend'] ) ) {
 			//return false;
 		}*/
-		if ( ! isset( $this->options['add_legend'] ) || null === $this->options['add_legend'] ) {
+		if (
+			! isset( $this->options['add_legend'] )
+			|| null === $this->options['add_legend']
+			|| ! in_array( $this->currentDisplay, $this->options['add_legend'] )
+		) {
 			return false;
 		}
 

--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -93,6 +93,9 @@ class Frontend {
 			case 'map':
 				$hook_name = 'events-pro/v2/map/top-bar';
 				break;
+			case 'summary':
+				$hook_name = 'events-pro/v2/summary/top-bar';
+				break;
 		}
 		if ( $hook_name ) {
 			$this->legendTargetHook = "tribe_template_before_include:{$hook_name}";

--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -414,7 +414,7 @@ class Main {
 	 */
 	private function update_view_options( $views, $options ) {
 		if ( ! is_array( $options['add_legend'] ) && $options['add_legend'] == 1 ) {
-			$transfer[] = [ 'month' ];
+			$transfer[] = 'month';
 
 			foreach ( $views as $view ) {
 				if ( ! empty( $options["add_legend_{$view}_view"] ) ) {

--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -122,6 +122,9 @@ class Main {
 		if ( ! empty( $options['add_legend_map_view'] ) && $options['add_legend_map_view'] ) {
 			teccc_add_legend_view( 'map' );
 		}
+		if ( ! empty( $options['add_legend_summary_view'] ) && $options['add_legend_summary_view'] ) {
+			teccc_add_legend_view( 'summary' );
+		}
 
 	}
 

--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -118,7 +118,7 @@ class Main {
 		];
 
 		if ( !is_array( $options['add_legend'] ) ) {
-			$this->update_view_options( $views, $options );
+			$options = $this->update_view_options( $views, $options );
 		}
 
 		foreach ( $views as $view ) {
@@ -425,5 +425,7 @@ class Main {
 		}
 
 		update_option( 'teccc_options', $options );
+
+		return $options;
 	}
 }

--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -107,25 +107,21 @@ class Main {
 	public function show_legend_on_views() {
 		$options = get_option( 'teccc_options' );
 
-		if ( ! empty( $options['add_legend_list_view'] ) && $options['add_legend_list_view'] ) {
-			teccc_add_legend_view( 'list' );
-		}
-		if ( ! empty( $options['add_legend_day_view'] ) && $options['add_legend_day_view'] ) {
-			teccc_add_legend_view( 'day' );
-		}
-		if ( ! empty( $options['add_legend_week_view'] ) && $options['add_legend_week_view'] ) {
-			teccc_add_legend_view( 'week' );
-		}
-		if ( ! empty( $options['add_legend_photo_view'] ) && $options['add_legend_photo_view'] ) {
-			teccc_add_legend_view( 'photo' );
-		}
-		if ( ! empty( $options['add_legend_map_view'] ) && $options['add_legend_map_view'] ) {
-			teccc_add_legend_view( 'map' );
-		}
-		if ( ! empty( $options['add_legend_summary_view'] ) && $options['add_legend_summary_view'] ) {
-			teccc_add_legend_view( 'summary' );
-		}
+		$views = [
+			'list',
+			'month',
+			'day',
+			'week',
+			'photo',
+			'map',
+			'summary',
+		];
 
+		foreach ( $views as $view ) {
+			if ( in_array( $view, $options['add_legend']) ) {
+				teccc_add_legend_view( $view );
+			}
+		}
 	}
 
 	/**

--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -117,8 +117,12 @@ class Main {
 			'summary',
 		];
 
+		if ( !is_array( $options['add_legend'] ) ) {
+			$this->update_view_options( $views, $options );
+		}
+
 		foreach ( $views as $view ) {
-			if ( in_array( $view, $options['add_legend']) ) {
+			if ( in_array( $view, (array) $options['add_legend']) ) {
 				teccc_add_legend_view( $view );
 			}
 		}
@@ -400,5 +404,26 @@ class Main {
 	 */
 	public static function is_v2_active() {
 		return function_exists( 'tribe_events_views_v2_is_enabled' ) && \tribe_events_views_v2_is_enabled();
+	}
+
+	/**
+	 * Update the view options from single options to array
+	 *
+	 * @param $views
+	 * @param $options
+	 */
+	private function update_view_options( $views, $options ) {
+		if ( ! is_array( $options['add_legend'] ) && $options['add_legend'] == 1 ) {
+			$transfer[] = [ 'month' ];
+
+			foreach ( $views as $view ) {
+				if ( ! empty( $options["add_legend_{$view}_view"] ) ) {
+					$transfer[] = $view;
+				}
+			}
+			$options['add_legend'] = $transfer;
+		}
+
+		update_option( 'teccc_options', $options );
 	}
 }

--- a/src/resources/teccc-admin.js
+++ b/src/resources/teccc-admin.js
@@ -12,7 +12,7 @@ jQuery( document ).ready(
 		 * option is displayed (or else it is hidden).
 		 */
 		function toggleSuperpowersVisibility() {
-			if ($( legendOption ).attr( "checked" ) === "checked") {
+			if ($( legendOption ).prop( "checked" ) === "checked") {
 				$( relatedOptions ).slideDown();
 			} else {
 				$( relatedOptions ).slideUp();
@@ -26,7 +26,7 @@ jQuery( document ).ready(
 		function toggleColorControls() {
 			var colorSelector = $( this ).parents( "td" ).find( ".colorselector" );
 
-			if ($( this ).attr( "checked" )) {
+			if ($( this ).prop( "checked" )) {
 				$( colorSelector ).slideUp();
 			} else {
 				$( colorSelector ).slideDown();
@@ -86,9 +86,9 @@ jQuery( document ).ready(
 					} else if (backgroundColor.test( inputName )) {
 						newBackgroundColor = $( this ).val();
 					} else if (borderTransparency.test( inputName )) {
-						newBorderTransparency = ($( this ).attr( "checked" ) === "checked");
+						newBorderTransparency = ($( this ).prop( "checked" ) === "checked");
 					} else if (backgroundTransparency.test( inputName )) {
-						newBackgroundTransparency = ($( this ).attr( "checked" ) === "checked");
+						newBackgroundTransparency = ($( this ).prop( "checked" ) === "checked");
 					} else if (fontColor.test( inputName )) {
 						newFontColor = $( this ).val();
 					}

--- a/src/resources/teccc-admin.js
+++ b/src/resources/teccc-admin.js
@@ -4,6 +4,9 @@
 jQuery( document ).ready(
 	function($) {
 		var legendOption         = $( "#category_legend_setting" ).find( "input" );
+		var legendOptions        = $( '#category_legend_checkboxes input[type=checkbox]' );
+		var legendOptionsCheckedInitial = $( '#category_legend_checkboxes input[type=checkbox]:checked' ).length;
+		var legendOptionsCheckedPrev;
 		var relatedOptions       = $( ".legend_related" );
 		var transparencySwitches = $( "td.color-control" ).find( "input[type='checkbox']" );
 
@@ -12,11 +15,21 @@ jQuery( document ).ready(
 		 * option is displayed (or else it is hidden).
 		 */
 		function toggleSuperpowersVisibility() {
-			if ( true === $( legendOption ).prop( "checked" )) {
-				$( relatedOptions ).slideDown();
-			} else {
+			var legendOptionsCheckedNow = $( '#category_legend_checkboxes input[type=checkbox]:checked' ).length;
+
+			if ( legendOptionsCheckedNow == 0 ) {
+				$( '.legend_related_notice' ).slideDown();
 				$( relatedOptions ).slideUp();
 			}
+			else if ( legendOptionsCheckedPrev == 0 && legendOptionsCheckedNow > 0 ){
+				$( '.legend_related_notice' ).slideUp();
+				$( relatedOptions ).slideDown();
+			}
+			else {
+				$( '.legend_related_notice' ).slideUp();
+			}
+
+			legendOptionsCheckedPrev = legendOptionsCheckedNow;
 		}
 
 		/**
@@ -36,7 +49,8 @@ jQuery( document ).ready(
 		// Toggle Legend Superpowers visibility initially, after the page loads
 		// (and run once on page load)
 		toggleSuperpowersVisibility();
-		$( legendOption ).change( toggleSuperpowersVisibility );
+		// $( legendOption ).change( toggleSuperpowersVisibility );
+		$( legendOptions ).change( toggleSuperpowersVisibility );
 
 		// Hide/show color selectors, according to whether transparency is checked
 		// (and run once on page load)

--- a/src/resources/teccc-admin.js
+++ b/src/resources/teccc-admin.js
@@ -12,7 +12,7 @@ jQuery( document ).ready(
 		 * option is displayed (or else it is hidden).
 		 */
 		function toggleSuperpowersVisibility() {
-			if ($( legendOption ).prop( "checked" ) === "checked") {
+			if ( true === $( legendOption ).prop( "checked" )) {
 				$( relatedOptions ).slideDown();
 			} else {
 				$( relatedOptions ).slideUp();

--- a/src/views/category.css.php
+++ b/src/views/category.css.php
@@ -92,7 +92,9 @@ if ( empty( $teccc->terms ) && ! empty( $options['terms'] ) ) {
 }
 <?php endforeach ?>
 
-<?php if ( ( '1' === $options['add_legend'] ) && null === $options['custom_legend_css'] ) : ?>
-	<?php $teccc->view( 'legend.css' ); ?>
-<?php endif ?>
+<?php
+if ( ! empty( $options['add_legend'] ) && null === $options['custom_legend_css'] ) {
+	$teccc->view( 'legend.css' );
+}
+?>
 <?php do_action( 'teccc_add_legend_css' ); ?>

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -165,36 +165,30 @@ $teccc->setup_terms( $options );
 
 	<div class="teccc_options_col1"> <?php esc_html_e( 'Show Category Legend', 'the-events-calendar-category-colors' ); ?> </div>
 	<div id="category_legend_setting" class="teccc_options_col2">
-		<label>
-			<input name="teccc_options[add_legend]" type="checkbox" value="1" <?php checked( '1', $options['add_legend'] ); ?> /> <?php esc_html_e( 'Month view', 'the-events-calendar-category-colors' ); ?>
-		</label>
+		<input id="teccc_options[add_legend_month_view]" name="teccc_options[add_legend]" type="checkbox" value="1" <?php checked( '1', $options['add_legend'] ); ?>>
+		<label for="teccc_options[add_legend_month_view]"><?php esc_html_e( 'Month view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_list_view" class="teccc_options_col2">
-		<label>
-			<input name="teccc_options[add_legend_list_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_list_view'] ); ?> /> <?php esc_html_e( 'List view', 'the-events-calendar-category-colors' ); ?>
-		</label>
+		<input id="teccc_options[add_legend_list_view]" name="teccc_options[add_legend_list_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_list_view'] ); ?>>
+		<label for="teccc_options[add_legend_list_view]"><?php esc_html_e( 'List view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_day_view" class="teccc_options_col2">
-		<label>
-			<input name="teccc_options[add_legend_day_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_day_view'] ); ?> /> <?php esc_html_e( 'Day view', 'the-events-calendar-category-colors' ); ?>
-		</label>
+		<input id="teccc_options[add_legend_day_view]" name="teccc_options[add_legend_day_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_day_view'] ); ?>>
+		<label for="teccc_options[add_legend_day_view]"><?php esc_html_e( 'Day view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 
 	<?php if ( class_exists( 'Tribe__Events__Pro__Main' ) ) : ?>
 	<div id="category_legend_setting_week_view" class="teccc_options_col2">
-		<label>
-			<input name="teccc_options[add_legend_week_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_week_view'] ); ?> /> <?php esc_html_e( 'Week view', 'the-events-calendar-category-colors' ); ?>
-		</label>
+		<input id="teccc_options[add_legend_week_view]" name="teccc_options[add_legend_week_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_week_view'] ); ?>>
+		<label for="teccc_options[add_legend_week_view]"><?php esc_html_e( 'Week view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_photo_view" class="teccc_options_col2">
-		<label>
-			<input name="teccc_options[add_legend_photo_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_photo_view'] ); ?> /> <?php esc_html_e( 'Photo view', 'the-events-calendar-category-colors' ); ?>
-		</label>
+		<input id="teccc_options[add_legend_photo_view]" name="teccc_options[add_legend_photo_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_photo_view'] ); ?>>
+		<label for="teccc_options[add_legend_photo_view]"><?php esc_html_e( 'Photo view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_map_view" class="teccc_options_col2">
-		<label>
-			<input name="teccc_options[add_legend_map_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_map_view'] ); ?> /> <?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?>
-		</label>
+		<input id="teccc_options[add_legend_map_view]" name="teccc_options[add_legend_map_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_map_view'] ); ?>>
+		<label for="teccc_options[add_legend_map_view]"><?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<?php endif; ?>
 

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -162,7 +162,7 @@ $teccc->setup_terms( $options );
 				<?php endforeach ?>
 			</select> </label>
 	</div>
-
+<div id="category_legend_checkboxes">
 	<div class="teccc_options_col1"> <?php esc_html_e( 'Show Category Legend', 'the-events-calendar-category-colors' ); ?> </div>
 	<div id="category_legend_setting" class="teccc_options_col2">
 		<input id="add_legend_month_view" name="teccc_options[add_legend][]" type="checkbox" value="month" <?php checked( 1, in_array('month', $options['add_legend'] ) ); ?>>
@@ -195,14 +195,17 @@ $teccc->setup_terms( $options );
 		<label for="add_legend_summary_view"><?php esc_html_e( 'Summary view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<?php endif; ?>
-
+</div>
 	<!-- Add Legend Superpowers -->
 	<div class="teccc_options_col1"> <?php esc_html_e( 'Legend Superpowers', 'the-events-calendar-category-colors' ); ?> </div>
+	<div class="teccc_options_col2 legend_related_notice">
+		<?php esc_html_e( 'For this option you have to show the category legend at least on one view.', 'the-events-calendar-category-colors' ); ?>
+	</div>
 	<div class="teccc_options_col2 legend_related">
 		<label>
 			<input name="teccc_options[legend_superpowers]" type="checkbox" value="1" <?php checked( '1', $options['legend_superpowers'] ); ?> /> <?php esc_html_e( 'Check to add Legend Superpowers.', 'the-events-calendar-category-colors' ); ?>
 		</label>
-		<p> <?php esc_html_e( 'Legend Superpowers are an optional visual effect allowing visitors to focus only on those events that belong to categories of interest - without reloading the page and without eliminating other categories from view completely. Click on the category of interest in the Legend for the effect; click again to remove it.', 'the-events-calendar-category-colors' ); ?> </p>
+		<p><?php esc_html_e( 'Legend Superpowers are an optional visual effect allowing visitors to focus only on those events that belong to categories of interest - without reloading the page and without eliminating other categories from view completely. Click on the category of interest in the Legend for the effect; click again to remove it.', 'the-events-calendar-category-colors' ); ?> </p>
 	</div>
 
 	<div class="teccc_options_col1 legend_related"><!-- Show Hidden Categories --></div>

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -165,33 +165,33 @@ $teccc->setup_terms( $options );
 
 	<div class="teccc_options_col1"> <?php esc_html_e( 'Show Category Legend', 'the-events-calendar-category-colors' ); ?> </div>
 	<div id="category_legend_setting" class="teccc_options_col2">
-		<input id="add_legend_month_view" name="teccc_options[add_legend][]" type="checkbox" value="month" <?php checked( 1, in_array('month', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_month_view" name="teccc_options['add_legend'][]" type="checkbox" value="month" <?php checked( 1, in_array('month', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_month_view"><?php esc_html_e( 'Month view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_list_view" class="teccc_options_col2">
-		<input id="add_legend_list_view" name="teccc_options[add_legend][]" type="checkbox" value="list" <?php checked( '1', in_array('list', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_list_view" name="teccc_options['add_legend'][]" type="checkbox" value="list" <?php checked( '1', in_array('list', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_list_view"><?php esc_html_e( 'List view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_day_view" class="teccc_options_col2">
-		<input id="add_legend_day_view" name="teccc_options[add_legend][]" type="checkbox" value="day" <?php checked( '1', in_array('day', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_day_view" name="teccc_options['add_legend'][]" type="checkbox" value="day" <?php checked( '1', in_array('day', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_day_view"><?php esc_html_e( 'Day view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 
 	<?php if ( class_exists( 'Tribe__Events__Pro__Main' ) ) : ?>
 	<div id="category_legend_setting_week_view" class="teccc_options_col2">
-		<input id="add_legend_week_view" name="teccc_options[add_legend][]" type="checkbox" value="week" <?php checked( '1', in_array('week', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_week_view" name="teccc_options['add_legend'][]" type="checkbox" value="week" <?php checked( '1', in_array('week', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_week_view"><?php esc_html_e( 'Week view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_photo_view" class="teccc_options_col2">
-		<input id="add_legend_photo_view" name="teccc_options[add_legend][]" type="checkbox" value="photo" <?php checked( '1', in_array('photo', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_photo_view" name="teccc_options['add_legend'][]" type="checkbox" value="photo" <?php checked( '1', in_array('photo', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_photo_view"><?php esc_html_e( 'Photo view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_map_view" class="teccc_options_col2">
-		<input id="add_legend_map_view" name="teccc_options[add_legend][]" type="checkbox" value="map" <?php checked( '1', in_array('map', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_map_view" name="teccc_options['add_legend'][]" type="checkbox" value="map" <?php checked( '1', in_array('map', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_map_view"><?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_summary_view" class="teccc_options_col2">
-		<input id="add_legend_summary_view" name="teccc_options[add_legend][]" type="checkbox" value="summary" <?php checked( '1', in_array('summary', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_summary_view" name="teccc_options['add_legend'][]" type="checkbox" value="summary" <?php checked( '1', in_array('summary', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_summary_view"><?php esc_html_e( 'Summary view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<?php endif; ?>

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -185,15 +185,18 @@ $teccc->setup_terms( $options );
 
 	<!-- Add Reset Button -->
 	<div class="teccc_options_col1"> <?php esc_html_e( 'Reset Button', 'the-events-calendar-category-colors' ); ?> </div>
-	<div class="teccc_options_col2">
+	<div class="teccc_options_col2 legend_related_notice">
+		<?php esc_html_e( 'For this option you have to show the category legend at least on one view.', 'the-events-calendar-category-colors' ); ?>
+	</div>
+	<div class="teccc_options_col2 legend_related">
 		<input name="teccc_options[reset_show]" type="checkbox" value="1" <?php checked( '1', $options['reset_show'] ); ?> />
 		<label for="teccc_options[reset_show]"><?php esc_html_e( 'Show reset button', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
-	<div class="teccc_options_col2">
+	<div class="teccc_options_col2 legend_related">
 		<input name="teccc_options[reset_label]" type="text" placeholder="<?php esc_html_e( 'Reset', 'the-events-calendar-category-colors' ); ?>" value="<?php echo $options['reset_label']; ?>" />
 		<label for="teccc_options[reset_label]"><?php esc_html_e( 'Reset button label', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
-	<div class="teccc_options_col2">
+	<div class="teccc_options_col2 legend_related">
 		<input name="teccc_options[reset_url]" type="text" placeholder="<?php echo tribe_get_events_link(); ?>" value="<?php echo $options['reset_url']; ?>" />
 		<label for="teccc_options[reset_url]"><?php esc_html_e( 'Reset button URL', 'the-events-calendar-category-colors' ); ?></label>
 		<p><?php esc_html_e( 'By default the reset button will point to the default calendar URL.', 'the-events-calendar-category-colors' ); ?></p>

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -162,40 +162,42 @@ $teccc->setup_terms( $options );
 				<?php endforeach ?>
 			</select> </label>
 	</div>
-<div id="category_legend_checkboxes">
-	<div class="teccc_options_col1"> <?php esc_html_e( 'Show Category Legend', 'the-events-calendar-category-colors' ); ?> </div>
-	<div id="category_legend_setting" class="teccc_options_col2">
-		<input id="add_legend_month_view" name="teccc_options[add_legend][]" type="checkbox" value="month" <?php checked( 1, in_array('month', $options['add_legend'] ) ); ?>>
-		<label for="add_legend_month_view"><?php esc_html_e( 'Month view', 'the-events-calendar-category-colors' ); ?></label>
-	</div>
-	<div id="category_legend_setting_list_view" class="teccc_options_col2">
-		<input id="add_legend_list_view" name="teccc_options[add_legend][]" type="checkbox" value="list" <?php checked( '1', in_array('list', $options['add_legend'] ) ); ?>>
-		<label for="add_legend_list_view"><?php esc_html_e( 'List view', 'the-events-calendar-category-colors' ); ?></label>
-	</div>
-	<div id="category_legend_setting_day_view" class="teccc_options_col2">
-		<input id="add_legend_day_view" name="teccc_options[add_legend][]" type="checkbox" value="day" <?php checked( '1', in_array('day', $options['add_legend'] ) ); ?>>
-		<label for="add_legend_day_view"><?php esc_html_e( 'Day view', 'the-events-calendar-category-colors' ); ?></label>
-	</div>
 
-	<?php if ( class_exists( 'Tribe__Events__Pro__Main' ) ) : ?>
-	<div id="category_legend_setting_week_view" class="teccc_options_col2">
-		<input id="add_legend_week_view" name="teccc_options[add_legend][]" type="checkbox" value="week" <?php checked( '1', in_array('week', $options['add_legend'] ) ); ?>>
-		<label for="add_legend_week_view"><?php esc_html_e( 'Week view', 'the-events-calendar-category-colors' ); ?></label>
+	<div id="category_legend_checkboxes">
+		<div class="teccc_options_col1"> <?php esc_html_e( 'Show Category Legend', 'the-events-calendar-category-colors' ); ?> </div>
+		<div id="category_legend_setting" class="teccc_options_col2">
+			<input id="add_legend_month_view" name="teccc_options[add_legend][]" type="checkbox" value="month" <?php checked( 1, in_array('month', $options['add_legend'] ) ); ?>>
+			<label for="add_legend_month_view"><?php esc_html_e( 'Month view', 'the-events-calendar-category-colors' ); ?></label>
+		</div>
+		<div id="category_legend_setting_list_view" class="teccc_options_col2">
+			<input id="add_legend_list_view" name="teccc_options[add_legend][]" type="checkbox" value="list" <?php checked( '1', in_array('list', $options['add_legend'] ) ); ?>>
+			<label for="add_legend_list_view"><?php esc_html_e( 'List view', 'the-events-calendar-category-colors' ); ?></label>
+		</div>
+		<div id="category_legend_setting_day_view" class="teccc_options_col2">
+			<input id="add_legend_day_view" name="teccc_options[add_legend][]" type="checkbox" value="day" <?php checked( '1', in_array('day', $options['add_legend'] ) ); ?>>
+			<label for="add_legend_day_view"><?php esc_html_e( 'Day view', 'the-events-calendar-category-colors' ); ?></label>
+		</div>
+
+		<?php if ( class_exists( 'Tribe__Events__Pro__Main' ) ) : ?>
+		<div id="category_legend_setting_week_view" class="teccc_options_col2">
+			<input id="add_legend_week_view" name="teccc_options[add_legend][]" type="checkbox" value="week" <?php checked( '1', in_array('week', $options['add_legend'] ) ); ?>>
+			<label for="add_legend_week_view"><?php esc_html_e( 'Week view', 'the-events-calendar-category-colors' ); ?></label>
+		</div>
+		<div id="category_legend_setting_photo_view" class="teccc_options_col2">
+			<input id="add_legend_photo_view" name="teccc_options[add_legend][]" type="checkbox" value="photo" <?php checked( '1', in_array('photo', $options['add_legend'] ) ); ?>>
+			<label for="add_legend_photo_view"><?php esc_html_e( 'Photo view', 'the-events-calendar-category-colors' ); ?></label>
+		</div>
+		<div id="category_legend_setting_map_view" class="teccc_options_col2">
+			<input id="add_legend_map_view" name="teccc_options[add_legend][]" type="checkbox" value="map" <?php checked( '1', in_array('map', $options['add_legend'] ) ); ?>>
+			<label for="add_legend_map_view"><?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?></label>
+		</div>
+		<div id="category_legend_setting_summary_view" class="teccc_options_col2">
+			<input id="add_legend_summary_view" name="teccc_options[add_legend][]" type="checkbox" value="summary" <?php checked( '1', in_array('summary', $options['add_legend'] ) ); ?>>
+			<label for="add_legend_summary_view"><?php esc_html_e( 'Summary view', 'the-events-calendar-category-colors' ); ?></label>
+		</div>
+		<?php endif; ?>
 	</div>
-	<div id="category_legend_setting_photo_view" class="teccc_options_col2">
-		<input id="add_legend_photo_view" name="teccc_options[add_legend][]" type="checkbox" value="photo" <?php checked( '1', in_array('photo', $options['add_legend'] ) ); ?>>
-		<label for="add_legend_photo_view"><?php esc_html_e( 'Photo view', 'the-events-calendar-category-colors' ); ?></label>
-	</div>
-	<div id="category_legend_setting_map_view" class="teccc_options_col2">
-		<input id="add_legend_map_view" name="teccc_options[add_legend][]" type="checkbox" value="map" <?php checked( '1', in_array('map', $options['add_legend'] ) ); ?>>
-		<label for="add_legend_map_view"><?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?></label>
-	</div>
-	<div id="category_legend_setting_summary_view" class="teccc_options_col2">
-		<input id="add_legend_summary_view" name="teccc_options[add_legend][]" type="checkbox" value="summary" <?php checked( '1', in_array('summary', $options['add_legend'] ) ); ?>>
-		<label for="add_legend_summary_view"><?php esc_html_e( 'Summary view', 'the-events-calendar-category-colors' ); ?></label>
-	</div>
-	<?php endif; ?>
-</div>
+	
 	<!-- Add Legend Superpowers -->
 	<div class="teccc_options_col1"> <?php esc_html_e( 'Legend Superpowers', 'the-events-calendar-category-colors' ); ?> </div>
 	<div class="teccc_options_col2 legend_related_notice">

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -137,21 +137,6 @@ $teccc->setup_terms( $options );
 
 <div id="teccc_options">
 
-	<div class="teccc_options_col1"> <?php esc_html_e( 'Reset Button', 'the-events-calendar-category-colors' ); ?> </div>
-	<div class="teccc_options_col2">
-		<input name="teccc_options[reset_show]" type="checkbox" value="1" <?php checked( '1', $options['reset_show'] ); ?> />
-		<label for="teccc_options[reset_show]"><?php esc_html_e( 'Show reset button', 'the-events-calendar-category-colors' ); ?></label>
-	</div>
-	<div class="teccc_options_col2">
-		<input name="teccc_options[reset_label]" type="text" placeholder="Reset" value="<?php echo $options['reset_label']; ?>" />
-		<label for="teccc_options[reset_label]">Reset button label</label>
-	</div>
-	<div class="teccc_options_col2">
-		<input name="teccc_options[reset_url]" type="text" placeholder="<?php echo tribe_get_events_link(); ?>" value="<?php echo $options['reset_url']; ?>" />
-		<label for="teccc_options[reset_url]">Reset button URL</label>
-		<p>By default the reset button will point to the default calendar URL.</p>
-	</div>
-
 	<div class="teccc_options_col1"> <?php esc_html_e( 'Font-Weight Options', 'the-events-calendar-category-colors' ); ?> </div>
 	<div class="teccc_options_col2">
 		<label> <select name="teccc_options[font_weight]" id="teccc_font_weight">
@@ -197,7 +182,23 @@ $teccc->setup_terms( $options );
 		</div>
 		<?php endif; ?>
 	</div>
-	
+
+	<!-- Add Reset Button -->
+	<div class="teccc_options_col1"> <?php esc_html_e( 'Reset Button', 'the-events-calendar-category-colors' ); ?> </div>
+	<div class="teccc_options_col2">
+		<input name="teccc_options[reset_show]" type="checkbox" value="1" <?php checked( '1', $options['reset_show'] ); ?> />
+		<label for="teccc_options[reset_show]"><?php esc_html_e( 'Show reset button', 'the-events-calendar-category-colors' ); ?></label>
+	</div>
+	<div class="teccc_options_col2">
+		<input name="teccc_options[reset_label]" type="text" placeholder="Reset" value="<?php echo $options['reset_label']; ?>" />
+		<label for="teccc_options[reset_label]">Reset button label</label>
+	</div>
+	<div class="teccc_options_col2">
+		<input name="teccc_options[reset_url]" type="text" placeholder="<?php echo tribe_get_events_link(); ?>" value="<?php echo $options['reset_url']; ?>" />
+		<label for="teccc_options[reset_url]">Reset button URL</label>
+		<p>By default the reset button will point to the default calendar URL.</p>
+	</div>
+
 	<!-- Add Legend Superpowers -->
 	<div class="teccc_options_col1"> <?php esc_html_e( 'Legend Superpowers', 'the-events-calendar-category-colors' ); ?> </div>
 	<div class="teccc_options_col2 legend_related_notice">

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -165,34 +165,34 @@ $teccc->setup_terms( $options );
 
 	<div class="teccc_options_col1"> <?php esc_html_e( 'Show Category Legend', 'the-events-calendar-category-colors' ); ?> </div>
 	<div id="category_legend_setting" class="teccc_options_col2">
-		<input id="teccc_options[add_legend_month_view]" name="teccc_options[add_legend]" type="checkbox" value="1" <?php checked( '1', $options['add_legend'] ); ?>>
-		<label for="teccc_options[add_legend_month_view]"><?php esc_html_e( 'Month view', 'the-events-calendar-category-colors' ); ?></label>
+		<input id="add_legend_month_view" name="teccc_options[add_legend][]" type="checkbox" value="month" <?php checked( 1, in_array('month', $options['add_legend'] ) ); ?>>
+		<label for="add_legend_month_view"><?php esc_html_e( 'Month view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_list_view" class="teccc_options_col2">
-		<input id="teccc_options[add_legend_list_view]" name="teccc_options[add_legend_list_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_list_view'] ); ?>>
-		<label for="teccc_options[add_legend_list_view]"><?php esc_html_e( 'List view', 'the-events-calendar-category-colors' ); ?></label>
+		<input id="add_legend_list_view" name="teccc_options[add_legend][]" type="checkbox" value="list" <?php checked( '1', in_array('list', $options['add_legend'] ) ); ?>>
+		<label for="add_legend_list_view"><?php esc_html_e( 'List view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_day_view" class="teccc_options_col2">
-		<input id="teccc_options[add_legend_day_view]" name="teccc_options[add_legend_day_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_day_view'] ); ?>>
-		<label for="teccc_options[add_legend_day_view]"><?php esc_html_e( 'Day view', 'the-events-calendar-category-colors' ); ?></label>
+		<input id="add_legend_day_view" name="teccc_options[add_legend][]" type="checkbox" value="day" <?php checked( '1', in_array('day', $options['add_legend'] ) ); ?>>
+		<label for="add_legend_day_view"><?php esc_html_e( 'Day view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 
 	<?php if ( class_exists( 'Tribe__Events__Pro__Main' ) ) : ?>
 	<div id="category_legend_setting_week_view" class="teccc_options_col2">
-		<input id="teccc_options[add_legend_week_view]" name="teccc_options[add_legend_week_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_week_view'] ); ?>>
-		<label for="teccc_options[add_legend_week_view]"><?php esc_html_e( 'Week view', 'the-events-calendar-category-colors' ); ?></label>
+		<input id="add_legend_week_view" name="teccc_options[add_legend][]" type="checkbox" value="week" <?php checked( '1', in_array('week', $options['add_legend'] ) ); ?>>
+		<label for="add_legend_week_view"><?php esc_html_e( 'Week view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_photo_view" class="teccc_options_col2">
-		<input id="teccc_options[add_legend_photo_view]" name="teccc_options[add_legend_photo_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_photo_view'] ); ?>>
-		<label for="teccc_options[add_legend_photo_view]"><?php esc_html_e( 'Photo view', 'the-events-calendar-category-colors' ); ?></label>
+		<input id="add_legend_photo_view" name="teccc_options[add_legend][]" type="checkbox" value="photo" <?php checked( '1', in_array('photo', $options['add_legend'] ) ); ?>>
+		<label for="add_legend_photo_view"><?php esc_html_e( 'Photo view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_map_view" class="teccc_options_col2">
-		<input id="teccc_options[add_legend_map_view]" name="teccc_options[add_legend_map_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_map_view'] ); ?>>
-		<label for="teccc_options[add_legend_map_view]"><?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?></label>
+		<input id="add_legend_map_view" name="teccc_options[add_legend][]" type="checkbox" value="map" <?php checked( '1', in_array('map', $options['add_legend'] ) ); ?>>
+		<label for="add_legend_map_view"><?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_summary_view" class="teccc_options_col2">
-		<input id="teccc_options[add_legend_summary_view]" name="teccc_options[add_legend_summary_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_summary_view'] ); ?>>
-		<label for="teccc_options[add_legend_summary_view]"><?php esc_html_e( 'Summary view', 'the-events-calendar-category-colors' ); ?></label>
+		<input id="add_legend_summary_view" name="teccc_options[add_legend][]" type="checkbox" value="summary" <?php checked( '1', in_array('summary', $options['add_legend'] ) ); ?>>
+		<label for="add_legend_summary_view"><?php esc_html_e( 'Summary view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<?php endif; ?>
 

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -165,33 +165,33 @@ $teccc->setup_terms( $options );
 
 	<div class="teccc_options_col1"> <?php esc_html_e( 'Show Category Legend', 'the-events-calendar-category-colors' ); ?> </div>
 	<div id="category_legend_setting" class="teccc_options_col2">
-		<input id="add_legend_month_view" name="teccc_options['add_legend'][]" type="checkbox" value="month" <?php checked( 1, in_array('month', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_month_view" name="teccc_options[add_legend][]" type="checkbox" value="month" <?php checked( 1, in_array('month', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_month_view"><?php esc_html_e( 'Month view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_list_view" class="teccc_options_col2">
-		<input id="add_legend_list_view" name="teccc_options['add_legend'][]" type="checkbox" value="list" <?php checked( '1', in_array('list', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_list_view" name="teccc_options[add_legend][]" type="checkbox" value="list" <?php checked( '1', in_array('list', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_list_view"><?php esc_html_e( 'List view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_day_view" class="teccc_options_col2">
-		<input id="add_legend_day_view" name="teccc_options['add_legend'][]" type="checkbox" value="day" <?php checked( '1', in_array('day', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_day_view" name="teccc_options[add_legend][]" type="checkbox" value="day" <?php checked( '1', in_array('day', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_day_view"><?php esc_html_e( 'Day view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 
 	<?php if ( class_exists( 'Tribe__Events__Pro__Main' ) ) : ?>
 	<div id="category_legend_setting_week_view" class="teccc_options_col2">
-		<input id="add_legend_week_view" name="teccc_options['add_legend'][]" type="checkbox" value="week" <?php checked( '1', in_array('week', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_week_view" name="teccc_options[add_legend][]" type="checkbox" value="week" <?php checked( '1', in_array('week', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_week_view"><?php esc_html_e( 'Week view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_photo_view" class="teccc_options_col2">
-		<input id="add_legend_photo_view" name="teccc_options['add_legend'][]" type="checkbox" value="photo" <?php checked( '1', in_array('photo', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_photo_view" name="teccc_options[add_legend][]" type="checkbox" value="photo" <?php checked( '1', in_array('photo', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_photo_view"><?php esc_html_e( 'Photo view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_map_view" class="teccc_options_col2">
-		<input id="add_legend_map_view" name="teccc_options['add_legend'][]" type="checkbox" value="map" <?php checked( '1', in_array('map', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_map_view" name="teccc_options[add_legend][]" type="checkbox" value="map" <?php checked( '1', in_array('map', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_map_view"><?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div id="category_legend_setting_summary_view" class="teccc_options_col2">
-		<input id="add_legend_summary_view" name="teccc_options['add_legend'][]" type="checkbox" value="summary" <?php checked( '1', in_array('summary', $options['add_legend'] ) ); ?>>
+		<input id="add_legend_summary_view" name="teccc_options[add_legend][]" type="checkbox" value="summary" <?php checked( '1', in_array('summary', $options['add_legend'] ) ); ?>>
 		<label for="add_legend_summary_view"><?php esc_html_e( 'Summary view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<?php endif; ?>

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -190,13 +190,13 @@ $teccc->setup_terms( $options );
 		<label for="teccc_options[reset_show]"><?php esc_html_e( 'Show reset button', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div class="teccc_options_col2">
-		<input name="teccc_options[reset_label]" type="text" placeholder="Reset" value="<?php echo $options['reset_label']; ?>" />
-		<label for="teccc_options[reset_label]">Reset button label</label>
+		<input name="teccc_options[reset_label]" type="text" placeholder="<?php esc_html_e( 'Reset', 'the-events-calendar-category-colors' ); ?>" value="<?php echo $options['reset_label']; ?>" />
+		<label for="teccc_options[reset_label]"><?php esc_html_e( 'Reset button label', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div class="teccc_options_col2">
 		<input name="teccc_options[reset_url]" type="text" placeholder="<?php echo tribe_get_events_link(); ?>" value="<?php echo $options['reset_url']; ?>" />
-		<label for="teccc_options[reset_url]">Reset button URL</label>
-		<p>By default the reset button will point to the default calendar URL.</p>
+		<label for="teccc_options[reset_url]"><?php esc_html_e( 'Reset button URL', 'the-events-calendar-category-colors' ); ?></label>
+		<p><?php esc_html_e( 'By default the reset button will point to the default calendar URL.', 'the-events-calendar-category-colors' ); ?></p>
 	</div>
 
 	<!-- Add Legend Superpowers -->

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -190,6 +190,10 @@ $teccc->setup_terms( $options );
 		<input id="teccc_options[add_legend_map_view]" name="teccc_options[add_legend_map_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_map_view'] ); ?>>
 		<label for="teccc_options[add_legend_map_view]"><?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
+	<div id="category_legend_setting_summary_view" class="teccc_options_col2">
+		<input id="teccc_options[add_legend_summary_view]" name="teccc_options[add_legend_summary_view]" type="checkbox" value="1" <?php checked( '1', $options['add_legend_summary_view'] ); ?>>
+		<label for="teccc_options[add_legend_summary_view]"><?php esc_html_e( 'Summary view', 'the-events-calendar-category-colors' ); ?></label>
+	</div>
 	<?php endif; ?>
 
 	<!-- Add Legend Superpowers -->


### PR DESCRIPTION
Fixed a couple of things.

- Category legend is properly displayed on the selected views.
- It's not needed to select month view anymore to show the category legend.
- Fixed the legend superpowers toggle behavior
- Fixed the color picker toggle behavior
- Made some strings for the reset button settings translatable
- Reset button settings are moved below the legend settings
- Reset button settings only show up when a view is selected