### PR TITLE
Allow file write operations to be disabled with a filter

### DIFF
--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -244,10 +244,20 @@ class Frontend {
 				unlink( $file );
 			}
 		}
-		file_put_contents( "{$css_dir}/{$this->cache_key}.css", $css );
-		file_put_contents( "{$css_dir}/{$this->cache_key}.min.css", $css_min );
-		chmod( "{$css_dir}/{$this->cache_key}.css", 0644 );
-		chmod( "{$css_dir}/{$this->cache_key}.min.css", 0644 );
+
+		/**
+		 * Filter to control whether to write CSS to a file. Some hosts do not permit file write operations.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param bool $write_files Whether to write CSS to disk.
+		 */
+		if ( apply_filters( 'teccc_write_files', true ) ) {
+			file_put_contents( "{$css_dir}/{$this->cache_key}.css", $css );
+			file_put_contents( "{$css_dir}/{$this->cache_key}.min.css", $css_min );
+			chmod( "{$css_dir}/{$this->cache_key}.css", 0644 );
+			chmod( "{$css_dir}/{$this->cache_key}.min.css", 0644 );
+		}
 
 		// Store in transient.
 		set_transient( 'teccc_cache_key', $this->cache_key, 4 * WEEK_IN_SECONDS );


### PR DESCRIPTION
On WordPress VIP this plugin appears to work correctly from an end-user's perspective, but it throws dozens and dozens of errors in the PHP logs because [write operations are not permitted on WordPress VIP](https://docs.wpvip.com/technical-references/vip-go-files-system/local-file-operations/) outside of a specific temp directory. (Most enterprise-grade hosts lock down file operations in a similar fashion.)

This PR introduces a new filter `teccc_write_files` which can be used to opt out from file writes and rely solely on the transient for storing the CSS.

Example usage:

    // Turn off file operations to silence PHP errors on deployed environment.
    add_filter( 'teccc_write_files', '__return_false' );