### PR TITLE
Fix event/legend dimming.

### DIFF
--- a/src/resources/legend-superpowers.js
+++ b/src/resources/legend-superpowers.js
@@ -81,21 +81,14 @@ jQuery( document ).ready(
 			const $allEntries = $(status.allEntries);
 			const $unselected = $allEntries.not(slug).not(slugv2);
 
-			// We only need to fade out unselected entries if there are less unselected entries than selected entries...
-			if ($unselected.length < $allEntries.length) {
-				$unselected.add(legendEntries.not(slug)).fadeTo(
-					status.speed,
-					status.opacity,
-					function () {
-						status.selected = selection;
-						status.working = false;
-					}
-				);
-			}
-			// ...Otherwise, it's probable that the persisted category selection does not exist on the current page.
-			else {
-				selection = '';
-			}
+			$unselected.add(legendEntries.not(slug)).fadeTo(
+				status.speed,
+				status.opacity,
+				function () {
+					status.selected = selection;
+					status.working = false;
+				}
+			);
 
 			persistSelection(selection);
 


### PR DESCRIPTION
Relating to the [conversation over here](https://github.com/afragen/the-events-calendar-category-colors/pull/147#issuecomment-1487207029): even if the selected category does not have items on the page, other events and legend entries should still be dimmed.

![unusued-cat-dimming](https://user-images.githubusercontent.com/3594411/228316423-3f2abc0d-1eda-4729-8ab8-546763fa39a1.gif)

☝🏼 In the above screencast, no items belonging to category **Unused** are present on the page, but we still get the dimming effect.

